### PR TITLE
Add strict mode & simplify regexp

### DIFF
--- a/slugifier.js
+++ b/slugifier.js
@@ -16,7 +16,7 @@ function copyToClipboard(text) {
 function slugify(text) {
   return text.trim().toLowerCase()
     .replace(/&/g, '-and-')
-    .replace(/[_\s]+/g, '-')
+    .replace(/[_\W]+/g, '-')
     .replace(/^-+|-+$/g, '')
 }
 

--- a/slugifier.js
+++ b/slugifier.js
@@ -1,3 +1,5 @@
+'use strict'
+
 function slugifySelection({ selectionText }) {
   copyToClipboard(slugify(selectionText))
 }
@@ -14,7 +16,7 @@ function copyToClipboard(text) {
 function slugify(text) {
   return text.trim().toLowerCase()
     .replace(/&/g, '-and-')
-    .replace(/[\s\W-_]+/g, '-')
+    .replace(/[_\s]+/g, '-')
     .replace(/^-+|-+$/g, '')
 }
 


### PR DESCRIPTION
`\w` matches `[A-Za-z0-9_]`, thus `\W` matches anything except that, whitespaces included. So `\s` and `-` are extra.